### PR TITLE
Use s01.oss.sonatype.org

### DIFF
--- a/convention-plugins/src/main/kotlin/root.publication.gradle.kts
+++ b/convention-plugins/src/main/kotlin/root.publication.gradle.kts
@@ -6,6 +6,9 @@ nexusPublishing {
     // Configure maven central repository
     // https://github.com/gradle-nexus/publish-plugin#publishing-to-maven-central-via-sonatype-ossrh
     repositories {
-        sonatype()
+        sonatype {  //only for users registered in Sonatype after 24 Feb 2021
+            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+        }
     }
 }


### PR DESCRIPTION
It seems the README is targeting users that aren't (that) familiar with publishing libraries.
In that case I think it's best to default to `s01.oss.sonatype.org` since all users that have created (and will create) a Sonatype account after 24 February 2021 will be on that server.