### PR TITLE
Validate Gradle wrapper

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
+    - name: Validate Gradle Wrapper
+      uses: gradle/wrapper-validation-action@v1
     - uses: actions/cache@v3
       with:
         path: |

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -36,6 +36,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Validate Gradle Wrapper
+      uses: gradle/wrapper-validation-action@v1
     - uses: actions/cache@v3
       with:
         path: |


### PR DESCRIPTION
Since we are including Github action workflows it's very likely the generates project will be open-source, so it would be best to validate the Gradle wrapper(s).