### PR TITLE
Update LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2023 JetBrains s.r.o. and and respective authors and developers.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
The current LICENSE file in this project has been altered to include JetBrains as the copyright owner. However, the Apache 2.0 license file should not be altered in any way and should be included in repos verbatim. The Appendix at the end is a template for people to apply the Apache License to their work (in the form of license headers in source code files), instead of a declaration of the owner of the current repo.