### PR TITLE
Remove signing key ID from publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,6 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY_CONTENTS }}
 


### PR DESCRIPTION
vanniktech plugin does not work with the existing setup that is fed both in-memory key and in-memory ID.
If signing key ID is supplied then it tries to resort to local keystore and no in-memory setup is used. Just remove key id to get signing working.

I verified it works at https://github.com/atsushieno/multiplatform-library-template-nexus-publisher/actions/runs/14993346954