### PR TITLE
Align version catalog aliases with a shared convention

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
 agp = "9.0.1"
-kotlin = "2.3.10"
-android-minSdk = "24"
 android-compileSdk = "36"
-vanniktechMavenPublish = "0.36.0"
+android-minSdk = "24"
+kotlin = "2.3.10"
+vanniktech-maven-publish = "0.36.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -11,4 +11,4 @@ kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotl
 [plugins]
 android-kotlin-multiplatform-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
-vanniktech-mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "vanniktechMavenPublish" }
+vanniktech-mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "vanniktech-maven-publish" }


### PR DESCRIPTION
Renames the version catalog aliases so that each dependency has one canonical name shared across the Kotlin Multiplatform samples, and sorts the `[versions]` block alphabetically. `androidx-*` covers `androidx.*` together with its `org.jetbrains.androidx.*` multiplatform ports, which share one alias per library, while `compose-*` is Compose Multiplatform itself; separate release trains stay separate, so `androidx-navigation` (2.x) and `androidx-navigation3` (1.x) are distinct aliases. No resolved dependency version changes: every rename keeps its value, and any aliases merged together already held identical versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
